### PR TITLE
folderを開いた時に表示される情報を取得するためのAPIを追加(DB未実装)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, FastAPI
 
 from backend.routes.bookmark import router as bookmark_router
+from backend.routes.contents import router as contents_router
 from backend.routes.folders import router as startpage_router
 from backend.routes.sign import router as sign_router
 
@@ -8,6 +9,7 @@ router = APIRouter()
 router.include_router(sign_router)
 router.include_router(startpage_router)
 router.include_router(bookmark_router)
+router.include_router(contents_router)
 
 app = FastAPI()
 app.include_router(router)

--- a/backend/models/schemas/contents.py
+++ b/backend/models/schemas/contents.py
@@ -1,0 +1,22 @@
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class ContentInfo(BaseModel):
+    url: str = Field(description="URL")
+    image: str = Field(description="イメージ画像のsrc")
+    description: str = Field(description="自動で付与される説明文")
+    title: str = Field(description="ページタイトル")
+    comment: str = Field(description="ユーザがつけるコメント")
+
+
+class Content(BaseModel):
+    id: UUID = Field(description="Contentのid")
+    info: ContentInfo = Field(description="Contentの情報")
+    children: Optional[List[Optional[UUID]]] = Field(description="子ノードのリスト(リストの順番は木の左からの順番)")
+
+
+class Contents(BaseModel):
+    contents: List[Content] = Field(description="Contentのリスト")

--- a/backend/routes/contents.py
+++ b/backend/routes/contents.py
@@ -1,0 +1,42 @@
+import random
+import uuid
+from uuid import UUID
+
+from backend.models.schemas.contents import Content, ContentInfo, Contents
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/contents/{folder_id}")
+def display_contents(folder_id: UUID) -> Contents:
+    # folder_idに該当するをデータを取得してくる
+    folder_id
+    content_info = ContentInfo(
+        url="https://kotsukotsu.work/tech/2020-09-13-vercel-%E3%82%A6%E3%82%A7%E3%83%96%E3%82%B5%E3%82%A4%E3%83%88%E3%81%AEogp%E6%83%85%E5%A0%B1%E3%82%92%E5%8F%96%E5%BE%97%E3%81%99%E3%82%8B-serverless-functions-%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B/",
+        image="https://kotsukotsu.work/media/kotsu2to-icon.png",
+        description="ウェブサイトのOGP 情報を取得する Serverless Functions を作成してみたので紹介します。",
+        title="[Vercel] ウェブサイトのOGP情報を取得する Serverless Functions を作成する",
+        comment="説明文",
+    )
+    nodes = [uuid.uuid4() for _ in range(5)]
+    if random.randint(0, 2) == 1:
+        contents = [
+            Content(id=nodes[0], info=content_info, children=[nodes[1], nodes[2]]),
+            Content(id=nodes[1], info=content_info, children=[nodes[3], nodes[4]]),
+            Content(id=nodes[2], info=content_info, children=[]),
+            Content(id=nodes[3], info=content_info, children=[]),
+            Content(id=nodes[4], info=content_info, children=[]),
+        ]
+
+        return Contents(contents=contents)
+    else:
+        contents = [
+            Content(id=nodes[0], info=content_info),
+            Content(id=nodes[1], info=content_info),
+            Content(id=nodes[2], info=content_info),
+            Content(id=nodes[3], info=content_info),
+            Content(id=nodes[4], info=content_info),
+        ]
+
+        return Contents(contents=contents)


### PR DESCRIPTION
folderを開いた時に必要となる木と集合の情報を返すAPIを実装しました。DB未実装のため、固定の値が返されます。
使用方法は、`http://127.0.0.1:8000/contents/{folder_id}`でgetで叩くと、情報が取得されます。folder_idはDB未実装なため
、テキトーなUUID4を入れてください([テキトーなUUID4の生成方法](https://uuid.doratool.com/))。