### PR TITLE
ogp取得機能を追加

### DIFF
--- a/backend/models/schemas/bookmark.py
+++ b/backend/models/schemas/bookmark.py
@@ -1,9 +1,18 @@
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field
 
 
+class OGP(BaseModel):
+    title: Optional[str] = Field(description="メタタグのog:titleから抽出できるもの")
+    image_url: Optional[str] = Field(description="メタタグのog:imageから抽出できるもの")
+    description: Optional[str] = Field(description="メタタグのog:descriptionから抽出できるもの")
+
+
 class BookMark(BaseModel):
-    status: bool = Field(description="登録が成功したか")
     id: UUID = Field(description="URLのid")
     url: str = Field(description="URL")
+    title: Optional[str] = Field(description="メタタグのog:titleから抽出できるもの")
+    image_url: Optional[str] = Field(description="メタタグのog:imageから抽出できるもの")
+    description: Optional[str] = Field(description="メタタグのog:descriptionから抽出できるもの")

--- a/backend/routes/bookmark.py
+++ b/backend/routes/bookmark.py
@@ -1,13 +1,46 @@
+import re
 import uuid
+from string import Template
+from typing import Optional
 
+import requests
 from fastapi import APIRouter
 
-from backend.models.schemas.bookmark import BookMark
+from backend.models.schemas.bookmark import OGP, BookMark
 
 router = APIRouter()
 
 
+def get_ogp(url: str) -> Optional[OGP]:
+    response = requests.get(url)
+
+    if response.status_code != 200:
+        return None
+
+    html: str = response.text
+
+    template = Template('<meta property="og:${og}" content="(.*?)"')
+    _image_url = re.search(template.substitute(og="image"), html, flags=re.DOTALL)
+    if _image_url:
+        image_url = _image_url.group(1)
+
+    _title = re.search(template.substitute(og="title"), html, flags=re.DOTALL)
+    if _title:
+        title = _title.group(1)
+
+    _description = re.search(template.substitute(og="description"), html, flags=re.DOTALL)
+    if _description:
+        description = _description.group(1)
+
+    return OGP(title=title, image_url=image_url, description=description)
+
+
 @router.post("/bookmark")
 def bookmark(url: str) -> BookMark:
-    status = True
-    return BookMark(**{"status": status, "id": uuid.uuid4(), "url": url})
+    bookmark = {"url": url}
+    # databaseを検索し、存在しなければogpを抽出してくる
+    if True:
+        if ogp := get_ogp(url):
+            bookmark.update(ogp.dict())
+    bookmark["id"] = uuid.uuid4()
+    return BookMark(**bookmark)


### PR DESCRIPTION
bookmark/ APIにogpを取得する機能を追加しました。データベース実装後は、データベースを検索してURLが登録されていない場合のみogpを追加することに変更します。