### PR TITLE
Contentsの型を変更

### DIFF
--- a/backend/models/schemas/contents.py
+++ b/backend/models/schemas/contents.py
@@ -1,4 +1,6 @@
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import List, Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -13,9 +15,10 @@ class ContentInfo(BaseModel):
 
 
 class Content(BaseModel):
+    type: Literal["tree", "set"] = Field(description="folderの種類")
     id: UUID = Field(description="Contentのid")
     info: ContentInfo = Field(description="Contentの情報")
-    children: Optional[List[Optional[UUID]]] = Field(description="子ノードのリスト(リストの順番は木の左からの順番)")
+    children: Optional[List[Optional[Content]]] = Field(description="子ノードのリスト(リストの順番は木の左からの順番)")
 
 
 class Contents(BaseModel):

--- a/backend/models/schemas/contents.py
+++ b/backend/models/schemas/contents.py
@@ -15,11 +15,11 @@ class ContentInfo(BaseModel):
 
 
 class Content(BaseModel):
-    type: Literal["tree", "set"] = Field(description="folderの種類")
     id: UUID = Field(description="Contentのid")
     info: ContentInfo = Field(description="Contentの情報")
     children: Optional[List[Optional[Content]]] = Field(description="子ノードのリスト(リストの順番は木の左からの順番)")
 
 
 class Contents(BaseModel):
+    type: Literal["tree", "set"] = Field(description="folderの種類")
     contents: List[Content] = Field(description="Contentのリスト")

--- a/backend/routes/contents.py
+++ b/backend/routes/contents.py
@@ -2,8 +2,9 @@ import random
 import uuid
 from uuid import UUID
 
-from backend.models.schemas.contents import Content, ContentInfo, Contents
 from fastapi import APIRouter
+
+from backend.models.schemas.contents import Content, ContentInfo, Contents
 
 router = APIRouter()
 
@@ -22,11 +23,21 @@ def display_contents(folder_id: UUID) -> Contents:
     nodes = [uuid.uuid4() for _ in range(5)]
     if random.randint(0, 2) == 1:
         contents = [
-            Content(id=nodes[0], info=content_info, children=[nodes[1], nodes[2]]),
-            Content(id=nodes[1], info=content_info, children=[nodes[3], nodes[4]]),
-            Content(id=nodes[2], info=content_info, children=[]),
-            Content(id=nodes[3], info=content_info, children=[]),
-            Content(id=nodes[4], info=content_info, children=[]),
+            Content(
+                id=nodes[0],
+                info=content_info,
+                children=[
+                    Content(
+                        id=nodes[1],
+                        info=content_info,
+                        children=[
+                            Content(id=nodes[3], info=content_info, children=[]),
+                            Content(id=nodes[4], info=content_info, children=[]),
+                        ],
+                    ),
+                    Content(id=nodes[2], info=content_info, children=[]),
+                ],
+            )
         ]
 
         return Contents(contents=contents)

--- a/backend/routes/contents.py
+++ b/backend/routes/contents.py
@@ -22,8 +22,10 @@ def display_contents(folder_id: UUID) -> Contents:
     )
     nodes = [uuid.uuid4() for _ in range(5)]
     if random.randint(0, 2) == 1:
+        type = "tree"
         contents = [
             Content(
+                type=type,
                 id=nodes[0],
                 info=content_info,
                 children=[
@@ -40,8 +42,9 @@ def display_contents(folder_id: UUID) -> Contents:
             )
         ]
 
-        return Contents(contents=contents)
+        return Contents(type=type, contents=contents)
     else:
+        type = "set"
         contents = [
             Content(id=nodes[0], info=content_info),
             Content(id=nodes[1], info=content_info),
@@ -50,4 +53,4 @@ def display_contents(folder_id: UUID) -> Contents:
             Content(id=nodes[4], info=content_info),
         ]
 
-        return Contents(contents=contents)
+        return Contents(type=type, contents=contents)


### PR DESCRIPTION
- contentsの種類がtreeかsetかを`type`に格納して返すように変更しました
- `children`の中身をidではなく、contentの内容を格納するように変更しました

詳しい動作について、/docsでご確認ください