### PR TITLE
backend側のdocker部分を切り離してdocker-composeで立ち上げられるように変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+backend/db/data/*
+!backend/db/data/.gitkeep
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -4,14 +4,47 @@
   - 基本的には上記の通りに進めていく。
   - 変更点は「開くパスを入力する欄が表示されるので、/usr/src/app を入力して[OK]ボタンをクリックする。」の開くパスの部分を「/usr/local/bookmark-app」とする。
 
-# backend側のサーバー起動方法
+# backend側の操作
+- 起動
 ```
-uvicorn backend.main:app --reload --port=8010
-```
-上記を`/usr/local/bookmark-app`で実行すると、以下が出力される。
-```
+cd backend
+docker-compose up -d --build
+
+>>>
+Docker Compose is now in the Docker CLI, try `docker compose up`
+
+Creating network "backend_default" with the default driver
+Building api
+[+] Building 3.3s (10/10) 
+
 ...
-> INFO:     Uvicorn running on http://127.0.0.1:8010 (Press CTRL+C to quit)
+
+Creating db ... done
+Creating api ... done
+```
+
+- logの確認方法
+上記を実行してもterminal上ではdockerの立ち上がりの情報しか出力されないため、api側のlogを確認するためには以下を実行する必要がある
+```
+docker-compose logs
+>>>
+Attaching to api, db
+api    | INFO:     Will watch for changes in these directories: ['/usr/src/backend']
+api    | INFO:     Uvicorn running on http://0.0.0.0:8001 (Press CTRL+C to quit)
+api    | INFO:     Started reloader process [1] using statreload
+api    | INFO:     Started server process [10]
+api    | INFO:     Waiting for application startup.
+api    | INFO:     Application startup complete.
 ...
 ```
-`http://127.0.0.1:8010`の部分にカーソルを1秒ほど合わせると、`転送ポートを使用してリンクにアクセスする`が出てくるため、クリックする。遷移後のリンクに`/docs`を追記すると、apiを試すことができる。
+正常に立ち上がっていることがわかるため、http://localhost:8001/docs にアクセスするとapiの挙動を確認することができる
+
+- containerを落とす場合
+```
+docker-compose down
+```
+
+- 立ち上げたコンテナの中に入りたい場合(※これは動作確認上でしか使用しない)
+```
+docker-compose exec api bash 
+```

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,11 +1,10 @@
 from fastapi import APIRouter, FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
-from backend.routes.bookmark import router as bookmark_router
-from backend.routes.contents import router as contents_router
-from backend.routes.folders import router as startpage_router
-from backend.routes.sign import router as sign_router
-from starlette.middleware.cors import CORSMiddleware
+from .routes.bookmark import router as bookmark_router
+from .routes.contents import router as contents_router
+from .routes.folders import router as startpage_router
+from .routes.sign import router as sign_router
 
 router = APIRouter()
 router.include_router(sign_router)

--- a/backend/api/routes/bookmark.py
+++ b/backend/api/routes/bookmark.py
@@ -6,7 +6,7 @@ from typing import Optional
 import requests
 from fastapi import APIRouter
 
-from backend.models.schemas.bookmark import OGP, BookMark, Url
+from ..models.schemas.bookmark import OGP, BookMark, Url
 
 router = APIRouter()
 

--- a/backend/api/routes/contents.py
+++ b/backend/api/routes/contents.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from fastapi import APIRouter
 
-from backend.models.schemas.contents import Content, ContentInfo, Contents
+from ..models.schemas.contents import Content, ContentInfo, Contents
 
 router = APIRouter()
 

--- a/backend/api/routes/folders.py
+++ b/backend/api/routes/folders.py
@@ -2,8 +2,9 @@ import random
 import uuid
 from uuid import UUID
 
-from backend.models.schemas.folders import Folder, FolderList
 from fastapi import APIRouter
+
+from ..models.schemas.folders import Folder, FolderList
 
 router = APIRouter()
 
@@ -12,8 +13,5 @@ router = APIRouter()
 def signup(user_id: UUID) -> FolderList:
     # user_idに該当するfoldersを取得してくる
     user_id
-    folder_list = [
-        Folder(**{"id": uuid.uuid4(), "title": f"title:{random.randint(0, 100)}"})
-        for _ in range(10)
-    ]
+    folder_list = [Folder(**{"id": uuid.uuid4(), "title": f"title:{random.randint(0, 100)}"}) for _ in range(10)]
     return FolderList(**{"folder_list": folder_list})

--- a/backend/api/routes/sign.py
+++ b/backend/api/routes/sign.py
@@ -2,7 +2,7 @@ import uuid
 
 from fastapi import APIRouter
 
-from backend.models.schemas.sign import Sign, SignIn, SignUp
+from ..models.schemas.sign import Sign, SignIn, SignUp
 
 router = APIRouter()
 

--- a/backend/db/initdb.d/create_user_table.sql
+++ b/backend/db/initdb.d/create_user_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE user (
+    id INT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(30) NOT NULL,
+    email VARCHAR(128) NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -26,4 +26,4 @@ services:
     ports:
       - 8001:8001
     volumes:
-      - ./api:/usr/src/server
+      - ./api:/usr/src/backend/api

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3"
+
+services:
+  db:
+    image: mysql:5.7
+    container_name: db
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_DATABASE: sample_db
+      MYSQL_USER: mysqluser
+      MYSQL_PASSWORD: mysqlpass
+    volumes:
+      - ./docker/db/conf.d/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./db/data:/var/lib/mysql
+      - ./db/initdb.d:/docker-entrypoint-initdb.d
+    ports:
+      - 3308:3308
+    command: --port 3308
+    tty: true
+
+  api:
+    depends_on:
+      - db
+    container_name: api
+    build: ./docker/api
+    ports:
+      - 8001:8001
+    volumes:
+      - ./api:/usr/src/server

--- a/backend/docker/api/dockerfile
+++ b/backend/docker/api/dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9
 
-WORKDIR /usr/src/server
+WORKDIR /usr/src/backend
 ADD requirements.txt .
 RUN pip install -r requirements.txt
 
-CMD ["uvicorn", "main:app", "--reload", "--host", "0.0.0.0", "--port", "8001"]
+CMD ["uvicorn", "api.main:app", "--reload", "--host", "0.0.0.0", "--port", "8001"]

--- a/backend/docker/api/dockerfile
+++ b/backend/docker/api/dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.9
+
+WORKDIR /usr/src/server
+ADD requirements.txt .
+RUN pip install -r requirements.txt
+
+CMD ["uvicorn", "main:app", "--reload", "--host", "0.0.0.0", "--port", "8001"]

--- a/backend/docker/api/requirements.txt
+++ b/backend/docker/api/requirements.txt
@@ -3,3 +3,4 @@ fastapi
 mysqlclient
 sqlmodel
 sqlalchemy
+requests

--- a/backend/docker/api/requirements.txt
+++ b/backend/docker/api/requirements.txt
@@ -1,0 +1,5 @@
+uvicorn
+fastapi
+mysqlclient
+sqlmodel
+sqlalchemy

--- a/backend/docker/db/conf.d/my.cnf
+++ b/backend/docker/db/conf.d/my.cnf
@@ -1,0 +1,10 @@
+[mysqld]   
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+skip-character-set-client-handshake
+
+[mysqldump]
+default-character-set=utf8mb4
+
+[client]
+default-character-set=utf8mb4

--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-alpine
 
-RUN apk update && apk add --virtual=module curl git python3 python3-dev py3-pip
+RUN apk update && apk add --virtual=module curl git
 
 WORKDIR /usr/local
 RUN git clone https://github.com/plue1011/bookmark-app.git
@@ -9,6 +9,5 @@ WORKDIR bookmark-app
 
 RUN npm install -g create-react-app
 RUN npm install axios
-RUN pip3 install uvicorn fastapi requests
 
 EXPOSE 8000 3000


### PR DESCRIPTION
DBを使用するため、バックエンド側の環境をdocker-composeで立ち上げられるように変更しました。
フロントエンド側は今まで通りですが、dockerfileについてpython部分が消去されているため確認お願いします。
また、バックエンド側の起動方法が修正されているため、README.mdを変更してあります。併せて確認お願いします。

少なくとも、以下は目を通してもらえると助かります。
- dockerfile
- README.md